### PR TITLE
refactor: stabilize ghcr build

### DIFF
--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -1,15 +1,17 @@
+---
+# yamllint disable rule:line-length rule:truthy
 name: Build and Deploy Docker Image
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
       - 'README.md'
       - 'DEPLOYMENT_GUIDE.md'
       - 'DOCKER_BUILD.md'
       - 'DEPLOYMENT.md'
   pull_request:
-    branches: [ main ]
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:
@@ -37,7 +39,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
@@ -63,6 +65,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false
 
       - name: Debug image information
         if: github.event_name != 'pull_request'
@@ -70,49 +74,6 @@ jobs:
           echo "Built images with tags: ${{ steps.meta.outputs.tags }}"
           echo "Registry: ${{ env.REGISTRY }}"
           echo "Image name: ${{ env.IMAGE_NAME }}"
-
-      - name: Make GHCR package public
-        if: github.event_name != 'pull_request'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PACKAGE: terminal-grounds-website
-          OWNER: ${{ github.repository_owner }}
-        run: |
-          echo "Attempting to make package public: $PACKAGE for owner: $OWNER"
-          set +e
-          
-          # Try user packages first
-          echo "Trying user packages endpoint..."
-          RESP=$(curl -sS -o /dev/null -w "%{http_code}" \
-            -X PUT \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/user/packages/container/$PACKAGE/visibility \
-            -d '{"visibility":"public"}')
-          echo "User packages response: $RESP"
-          
-          # If user packages didn't work, try organization packages
-          if [ "$RESP" != "200" ] && [ "$RESP" != "204" ]; then
-            echo "Trying organization packages endpoint..."
-            RESP2=$(curl -sS -o /dev/null -w "%{http_code}" \
-              -X PUT \
-              -H "Authorization: Bearer $GITHUB_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/orgs/$OWNER/packages/container/$PACKAGE/visibility \
-              -d '{"visibility":"public"}')
-            echo "Organization packages response: $RESP2"
-            
-            if [ "$RESP2" != "200" ] && [ "$RESP2" != "204" ]; then
-              echo "Warning: Could not make package public. Response codes: $RESP (user), $RESP2 (org)"
-              echo "Package may already be public or this may be the first push."
-            else
-              echo "Successfully made package public via organization endpoint"
-            fi
-          else
-            echo "Successfully made package public via user endpoint"
-          fi
 
       - name: Update deployment status
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -1,4 +1,3 @@
----
 # yamllint disable rule:line-length rule:truthy
 name: Build and Deploy Docker Image
 


### PR DESCRIPTION
## Summary
- remove auto-visibility call that required extra scopes
- disable provenance and SBOM generation to avoid attestation issues
- authenticate to GHCR as repo owner for reliable pushes

## Testing
- `yamllint .github/workflows/docker-build-deploy.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ad0780d5108326af5471be8f086907